### PR TITLE
[feat] リアルタイムモードでJSON/LOG形式のログ表示に対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"license": "MIT",
 	"engines": {
-		"node": "22.x"
+		"node": "26.x"
 	},
 	"scripts": {
 		"dev": "vite dev",
@@ -41,5 +41,5 @@
 		"svelte-i18n": "^4.0.1",
 		"tailwindcss": "^4.1.18"
 	},
-	"packageManager": "pnpm@10.8.0+sha512.0e82714d1b5b43c74610193cb20734897c1d00de89d0e18420aebc5977fa13d780a9cb05734624e81ebd81cc876cd464794850641c48b9544326b5622ca29971"
+	"packageManager": "pnpm@10.32.1"
 }

--- a/src/lib/types/realtime.ts
+++ b/src/lib/types/realtime.ts
@@ -9,6 +9,7 @@ export interface Packet {
     from_idx: number | undefined;
     to_idx: number | undefined;
     bubble_idx: number | undefined;
+    timestamp?: number;
 }
 
 export interface Agent {

--- a/src/lib/utils/log-converter.ts
+++ b/src/lib/utils/log-converter.ts
@@ -1,5 +1,11 @@
 import type { Agent, Packet } from '$lib/types/realtime';
 
+export function normalizeTimestamp(ts: number | undefined): number | undefined {
+    if (ts === undefined) return undefined;
+    if (ts < 1e12) return ts * 1000;
+    return ts;
+}
+
 interface GameLogAgent {
     idx: number;
     role: string;
@@ -69,6 +75,14 @@ export function convertGameLogToPackets(text: string, gameId?: string): Packet[]
                 break;
             case 'talk': {
                 const [, , agentIdx, ...textParts] = rest;
+                let talkTimestamp: number | undefined;
+                if (textParts.length > 1) {
+                    const lastPart = textParts[textParts.length - 1];
+                    if (/^\d{10,}$/.test(lastPart)) {
+                        talkTimestamp = parseInt(lastPart, 10);
+                        textParts.pop();
+                    }
+                }
                 const text = textParts.join(',');
                 isDay = true;
                 idx++;
@@ -83,11 +97,20 @@ export function convertGameLogToPackets(text: string, gameId?: string): Packet[]
                     from_idx: undefined,
                     to_idx: undefined,
                     bubble_idx: parseInt(agentIdx, 10),
+                    timestamp: normalizeTimestamp(talkTimestamp),
                 });
                 break;
             }
             case 'whisper': {
                 const [, , agentIdx, ...textParts] = rest;
+                let whisperTimestamp: number | undefined;
+                if (textParts.length > 1) {
+                    const lastPart = textParts[textParts.length - 1];
+                    if (/^\d{10,}$/.test(lastPart)) {
+                        whisperTimestamp = parseInt(lastPart, 10);
+                        textParts.pop();
+                    }
+                }
                 const text = textParts.join(',');
                 idx++;
                 packets.push({
@@ -101,6 +124,7 @@ export function convertGameLogToPackets(text: string, gameId?: string): Packet[]
                     from_idx: undefined,
                     to_idx: undefined,
                     bubble_idx: parseInt(agentIdx, 10),
+                    timestamp: normalizeTimestamp(whisperTimestamp),
                 });
                 break;
             }
@@ -274,6 +298,7 @@ interface TalkHistoryEntry {
     text: string;
     skip: boolean;
     over: boolean;
+    time?: number;
 }
 
 export function convertJSONLogToPackets(text: string): Packet[] {
@@ -455,6 +480,7 @@ export function convertJSONLogToPackets(text: string): Packet[] {
                     from_idx: undefined,
                     to_idx: undefined,
                     bubble_idx: agentIdx,
+                    timestamp: normalizeTimestamp(entry.response_timestamp),
                 });
                 break;
             }
@@ -473,6 +499,7 @@ export function convertJSONLogToPackets(text: string): Packet[] {
                     from_idx: undefined,
                     to_idx: undefined,
                     bubble_idx: agentIdx,
+                    timestamp: normalizeTimestamp(entry.response_timestamp),
                 });
                 break;
             }
@@ -496,6 +523,7 @@ export function convertJSONLogToPackets(text: string): Packet[] {
                         from_idx: undefined,
                         to_idx: undefined,
                         bubble_idx: talkAgentIdx,
+                        timestamp: normalizeTimestamp(talk.time),
                     });
                 }
                 const whisperHistory: TalkHistoryEntry[] = request.whisper_history || [];
@@ -516,6 +544,7 @@ export function convertJSONLogToPackets(text: string): Packet[] {
                         from_idx: undefined,
                         to_idx: undefined,
                         bubble_idx: whisperAgentIdx,
+                        timestamp: normalizeTimestamp(whisper.time),
                     });
                 }
                 break;
@@ -537,6 +566,7 @@ export function convertJSONLogToPackets(text: string): Packet[] {
                     from_idx: agentIdx,
                     to_idx: targetIdx,
                     bubble_idx: undefined,
+                    timestamp: normalizeTimestamp(entry.response_timestamp),
                 });
                 break;
             }
@@ -557,6 +587,7 @@ export function convertJSONLogToPackets(text: string): Packet[] {
                     from_idx: agentIdx,
                     to_idx: targetIdx,
                     bubble_idx: undefined,
+                    timestamp: normalizeTimestamp(entry.response_timestamp),
                 });
                 break;
             }
@@ -577,6 +608,7 @@ export function convertJSONLogToPackets(text: string): Packet[] {
                     from_idx: agentIdx,
                     to_idx: targetIdx,
                     bubble_idx: undefined,
+                    timestamp: normalizeTimestamp(entry.response_timestamp),
                 });
                 break;
             }
@@ -598,6 +630,7 @@ export function convertJSONLogToPackets(text: string): Packet[] {
                     from_idx: agentIdx,
                     to_idx: targetIdx,
                     bubble_idx: undefined,
+                    timestamp: normalizeTimestamp(entry.response_timestamp),
                 });
                 break;
             }

--- a/src/lib/utils/log-converter.ts
+++ b/src/lib/utils/log-converter.ts
@@ -266,6 +266,16 @@ interface JSONLogData {
     entries: JSONLogEntry[];
 }
 
+interface TalkHistoryEntry {
+    idx: number;
+    day: number;
+    turn: number;
+    agent: string;
+    text: string;
+    skip: boolean;
+    over: boolean;
+}
+
 export function convertJSONLogToPackets(text: string): Packet[] {
     let data: JSONLogData;
     try {
@@ -277,44 +287,93 @@ export function convertJSONLogToPackets(text: string): Packet[] {
     if (!data.game_id || !data.agents || !data.entries) return [];
 
     const packets: Packet[] = [];
-    let idx = 0;
+    let packetIdx = 0;
 
-    const agentNameToIdx: Record<string, number> = {};
-    const agentIdxToRole: Record<number, string> = {};
-
-    for (const agent of data.agents) {
-        agentNameToIdx[agent.name] = agent.idx;
-        agentIdxToRole[agent.idx] = agent.role;
-    }
-
+    const gameNameToIdx: Record<string, number> = {};
+    const gameNameToRole: Record<string, string> = {};
     const statusByDay: Record<number, Record<number, boolean>> = {};
 
+    // First pass: build game_name → idx mapping from INITIALIZE entries
+    // The entries use "game names" (e.g. ダイスケ) while agents array uses original names (e.g. CamelliaDragons1)
+    // Match by role between INITIALIZE role_map and agents array
+    const roleToIdxQueue: Record<string, number[]> = {};
+    for (const agent of data.agents) {
+        if (!roleToIdxQueue[agent.role]) roleToIdxQueue[agent.role] = [];
+        roleToIdxQueue[agent.role].push(agent.idx);
+    }
+
+    const roleAssignIdx: Record<string, number> = {};
+    for (const entry of data.entries) {
+        let request: any;
+        try { request = JSON.parse(entry.request); } catch { continue; }
+        if (request.request !== 'INITIALIZE') continue;
+
+        const gameName = request.info?.agent;
+        const roleMap = request.info?.role_map;
+        if (!gameName || !roleMap) continue;
+
+        const role = roleMap[gameName];
+        if (!role) continue;
+
+        gameNameToRole[gameName] = role;
+        if (!roleAssignIdx[role]) roleAssignIdx[role] = 0;
+        const queue = roleToIdxQueue[role];
+        if (queue && roleAssignIdx[role] < queue.length) {
+            gameNameToIdx[gameName] = queue[roleAssignIdx[role]];
+            roleAssignIdx[role]++;
+        }
+    }
+
+    // Also map original agent names (for logs that use those directly)
+    for (const agent of data.agents) {
+        if (!gameNameToIdx[agent.name]) {
+            gameNameToIdx[agent.name] = agent.idx;
+        }
+    }
+
+    function resolveIdx(name: string): number | undefined {
+        return gameNameToIdx[name];
+    }
+
     function buildAgents(day: number): Agent[] {
-        return data.agents.map((a) => ({
-            idx: a.idx,
-            team: a.team,
-            name: a.name,
-            profile: undefined,
-            avatar: undefined,
-            role: a.role,
-            is_alive: statusByDay[day]?.[a.idx] ?? true,
-        }));
+        return data.agents.map((a) => {
+            const gameName = Object.entries(gameNameToIdx).find(([, idx]) => idx === a.idx)?.[0] ?? a.name;
+            return {
+                idx: a.idx,
+                team: a.team,
+                name: gameName,
+                profile: undefined,
+                avatar: undefined,
+                role: a.role,
+                is_alive: statusByDay[day]?.[a.idx] ?? true,
+            };
+        });
     }
 
     function parseStatusMap(statusMap: Record<string, string>, day: number) {
         if (!statusByDay[day]) statusByDay[day] = {};
         for (const [name, status] of Object.entries(statusMap)) {
-            const agentIdx = agentNameToIdx[name];
+            const agentIdx = resolveIdx(name);
             if (agentIdx !== undefined) {
                 statusByDay[day][agentIdx] = status === 'ALIVE';
             }
         }
     }
 
-    idx++;
+    // Second pass: parse status maps from all entries to build alive/dead state
+    for (const entry of data.entries) {
+        let request: any;
+        try { request = JSON.parse(entry.request); } catch { continue; }
+        const info = request.info;
+        if (info?.status_map) {
+            parseStatusMap(info.status_map, info.day ?? 0);
+        }
+    }
+
+    packetIdx++;
     packets.push({
         id: data.game_id,
-        idx,
+        idx: packetIdx,
         day: 0,
         is_day: true,
         agents: buildAgents(0),
@@ -325,32 +384,28 @@ export function convertJSONLogToPackets(text: string): Packet[] {
         bubble_idx: undefined,
     });
 
+    // Track which talk_history entries we've already emitted (by day+idx)
+    const emittedTalks = new Set<string>();
+    const emittedWhispers = new Set<string>();
+
     for (const entry of data.entries) {
         let request: any;
-        try {
-            request = JSON.parse(entry.request);
-        } catch {
-            continue;
-        }
+        try { request = JSON.parse(entry.request); } catch { continue; }
 
         const requestType = request.request;
         const info = request.info;
         const day = info?.day ?? 0;
         const agentName = entry.agent;
-        const agentIdx = agentNameToIdx[agentName];
-
-        if (info?.status_map) {
-            parseStatusMap(info.status_map, day);
-        }
+        const agentIdx = resolveIdx(agentName);
 
         switch (requestType) {
             case 'TALK': {
                 const response = entry.response;
                 if (!response) break;
-                idx++;
+                packetIdx++;
                 packets.push({
                     id: data.game_id,
-                    idx,
+                    idx: packetIdx,
                     day,
                     is_day: true,
                     agents: buildAgents(day),
@@ -365,10 +420,10 @@ export function convertJSONLogToPackets(text: string): Packet[] {
             case 'WHISPER': {
                 const response = entry.response;
                 if (!response) break;
-                idx++;
+                packetIdx++;
                 packets.push({
                     id: data.game_id,
-                    idx,
+                    idx: packetIdx,
                     day,
                     is_day: false,
                     agents: buildAgents(day),
@@ -380,15 +435,59 @@ export function convertJSONLogToPackets(text: string): Packet[] {
                 });
                 break;
             }
+            case 'DAILY_FINISH': {
+                // Extract talk_history and whisper_history
+                const talkHistory: TalkHistoryEntry[] = request.talk_history || [];
+                for (const talk of talkHistory) {
+                    const key = `${talk.day}-talk-${talk.idx}`;
+                    if (emittedTalks.has(key)) continue;
+                    emittedTalks.add(key);
+                    const talkAgentIdx = resolveIdx(talk.agent);
+                    packetIdx++;
+                    packets.push({
+                        id: data.game_id,
+                        idx: packetIdx,
+                        day: talk.day,
+                        is_day: true,
+                        agents: buildAgents(talk.day),
+                        event: 'トーク',
+                        message: talk.text,
+                        from_idx: undefined,
+                        to_idx: undefined,
+                        bubble_idx: talkAgentIdx,
+                    });
+                }
+                const whisperHistory: TalkHistoryEntry[] = request.whisper_history || [];
+                for (const whisper of whisperHistory) {
+                    const key = `${whisper.day}-whisper-${whisper.idx}`;
+                    if (emittedWhispers.has(key)) continue;
+                    emittedWhispers.add(key);
+                    const whisperAgentIdx = resolveIdx(whisper.agent);
+                    packetIdx++;
+                    packets.push({
+                        id: data.game_id,
+                        idx: packetIdx,
+                        day: whisper.day,
+                        is_day: false,
+                        agents: buildAgents(whisper.day),
+                        event: '囁き',
+                        message: whisper.text,
+                        from_idx: undefined,
+                        to_idx: undefined,
+                        bubble_idx: whisperAgentIdx,
+                    });
+                }
+                break;
+            }
             case 'VOTE': {
                 const response = entry.response;
                 if (!response) break;
-                const targetIdx = agentNameToIdx[response];
+                const targetIdx = resolveIdx(response);
                 if (targetIdx === undefined) break;
-                idx++;
+                packetIdx++;
                 packets.push({
                     id: data.game_id,
-                    idx,
+                    idx: packetIdx,
                     day,
                     is_day: true,
                     agents: buildAgents(day),
@@ -403,12 +502,12 @@ export function convertJSONLogToPackets(text: string): Packet[] {
             case 'DIVINE': {
                 const response = entry.response;
                 if (!response) break;
-                const targetIdx = agentNameToIdx[response];
+                const targetIdx = resolveIdx(response);
                 if (targetIdx === undefined) break;
-                idx++;
+                packetIdx++;
                 packets.push({
                     id: data.game_id,
-                    idx,
+                    idx: packetIdx,
                     day,
                     is_day: false,
                     agents: buildAgents(day),
@@ -423,12 +522,12 @@ export function convertJSONLogToPackets(text: string): Packet[] {
             case 'GUARD': {
                 const response = entry.response;
                 if (!response) break;
-                const targetIdx = agentNameToIdx[response];
+                const targetIdx = resolveIdx(response);
                 if (targetIdx === undefined) break;
-                idx++;
+                packetIdx++;
                 packets.push({
                     id: data.game_id,
-                    idx,
+                    idx: packetIdx,
                     day,
                     is_day: false,
                     agents: buildAgents(day),
@@ -440,15 +539,16 @@ export function convertJSONLogToPackets(text: string): Packet[] {
                 });
                 break;
             }
-            case 'ATTACK_VOTE': {
+            case 'ATTACK_VOTE':
+            case 'ATTACK': {
                 const response = entry.response;
                 if (!response) break;
-                const targetIdx = agentNameToIdx[response];
+                const targetIdx = resolveIdx(response);
                 if (targetIdx === undefined) break;
-                idx++;
+                packetIdx++;
                 packets.push({
                     id: data.game_id,
-                    idx,
+                    idx: packetIdx,
                     day,
                     is_day: false,
                     agents: buildAgents(day),
@@ -465,10 +565,10 @@ export function convertJSONLogToPackets(text: string): Packet[] {
 
     if (data.win_side && data.win_side !== 'T_NONE') {
         const lastDay = packets.length > 0 ? packets[packets.length - 1].day : 0;
-        idx++;
+        packetIdx++;
         packets.push({
             id: data.game_id,
-            idx,
+            idx: packetIdx,
             day: lastDay,
             is_day: true,
             agents: buildAgents(lastDay),

--- a/src/lib/utils/log-converter.ts
+++ b/src/lib/utils/log-converter.ts
@@ -1,0 +1,522 @@
+import type { Agent, Packet } from '$lib/types/realtime';
+
+interface GameLogAgent {
+    idx: number;
+    role: string;
+    status: string;
+    originalName: string;
+    gameName: string;
+}
+
+export function convertGameLogToPackets(text: string, gameId?: string): Packet[] {
+    const lines = text.split(/\r?\n/).filter((line) => line.trim());
+    if (lines.length === 0) return [];
+
+    const id = gameId || 'game-log';
+    const packets: Packet[] = [];
+    let idx = 0;
+
+    const agentsByDay: Record<number, Record<number, GameLogAgent>> = {};
+
+    for (const line of lines) {
+        const [dayStr, type, ...rest] = line.split(',');
+        const day = parseInt(dayStr, 10);
+        if (isNaN(day)) continue;
+
+        if (type === 'status') {
+            if (!agentsByDay[day]) agentsByDay[day] = {};
+            const [agentIdx, role, status, originalName, gameName] = rest;
+            agentsByDay[day][parseInt(agentIdx, 10)] = {
+                idx: parseInt(agentIdx, 10),
+                role,
+                status,
+                originalName,
+                gameName,
+            };
+        }
+    }
+
+    function getAgentsForDay(day: number): Agent[] {
+        const dayAgents = agentsByDay[day] || agentsByDay[0] || {};
+        return Object.values(dayAgents).map((a) => ({
+            idx: a.idx,
+            team: a.originalName,
+            name: a.gameName,
+            profile: undefined,
+            avatar: undefined,
+            role: a.role,
+            is_alive: a.status === 'ALIVE',
+        }));
+    }
+
+    let currentDay = -1;
+    let isDay = true;
+
+    for (const line of lines) {
+        const [dayStr, type, ...rest] = line.split(',');
+        const day = parseInt(dayStr, 10);
+        if (isNaN(day)) continue;
+
+        if (day !== currentDay) {
+            currentDay = day;
+            isDay = true;
+        }
+
+        const agents = getAgentsForDay(day);
+
+        switch (type) {
+            case 'status':
+                break;
+            case 'talk': {
+                const [, , agentIdx, ...textParts] = rest;
+                const text = textParts.join(',');
+                isDay = true;
+                idx++;
+                packets.push({
+                    id,
+                    idx,
+                    day,
+                    is_day: true,
+                    agents,
+                    event: 'トーク',
+                    message: text,
+                    from_idx: undefined,
+                    to_idx: undefined,
+                    bubble_idx: parseInt(agentIdx, 10),
+                });
+                break;
+            }
+            case 'whisper': {
+                const [, , agentIdx, ...textParts] = rest;
+                const text = textParts.join(',');
+                idx++;
+                packets.push({
+                    id,
+                    idx,
+                    day,
+                    is_day: isDay,
+                    agents,
+                    event: '囁き',
+                    message: text,
+                    from_idx: undefined,
+                    to_idx: undefined,
+                    bubble_idx: parseInt(agentIdx, 10),
+                });
+                break;
+            }
+            case 'vote': {
+                const [fromIdx, toIdx] = rest;
+                idx++;
+                packets.push({
+                    id,
+                    idx,
+                    day,
+                    is_day: true,
+                    agents,
+                    event: '投票',
+                    message: undefined,
+                    from_idx: parseInt(fromIdx, 10),
+                    to_idx: parseInt(toIdx, 10),
+                    bubble_idx: undefined,
+                });
+                break;
+            }
+            case 'execute': {
+                const [executedIdx] = rest;
+                idx++;
+                packets.push({
+                    id,
+                    idx,
+                    day,
+                    is_day: true,
+                    agents,
+                    event: '追放',
+                    message: undefined,
+                    from_idx: undefined,
+                    to_idx: parseInt(executedIdx, 10),
+                    bubble_idx: undefined,
+                });
+                break;
+            }
+            case 'divine': {
+                const [seerIdx, targetIdx] = rest;
+                isDay = false;
+                idx++;
+                packets.push({
+                    id,
+                    idx,
+                    day,
+                    is_day: false,
+                    agents,
+                    event: '占い',
+                    message: undefined,
+                    from_idx: parseInt(seerIdx, 10),
+                    to_idx: parseInt(targetIdx, 10),
+                    bubble_idx: undefined,
+                });
+                break;
+            }
+            case 'guard': {
+                const [guardIdx, targetIdx] = rest;
+                isDay = false;
+                idx++;
+                packets.push({
+                    id,
+                    idx,
+                    day,
+                    is_day: false,
+                    agents,
+                    event: '護衛',
+                    message: undefined,
+                    from_idx: parseInt(guardIdx, 10),
+                    to_idx: parseInt(targetIdx, 10),
+                    bubble_idx: undefined,
+                });
+                break;
+            }
+            case 'attackVote': {
+                const [fromIdx, toIdx] = rest;
+                isDay = false;
+                idx++;
+                packets.push({
+                    id,
+                    idx,
+                    day,
+                    is_day: false,
+                    agents,
+                    event: '襲撃投票',
+                    message: undefined,
+                    from_idx: parseInt(fromIdx, 10),
+                    to_idx: parseInt(toIdx, 10),
+                    bubble_idx: undefined,
+                });
+                break;
+            }
+            case 'attack': {
+                const [targetIdx, isSuccessful] = rest;
+                isDay = false;
+                idx++;
+                const targetIdxNum = parseInt(targetIdx, 10);
+                packets.push({
+                    id,
+                    idx,
+                    day,
+                    is_day: false,
+                    agents,
+                    event: '襲撃',
+                    message: undefined,
+                    from_idx: isSuccessful === 'true' ? undefined : -1,
+                    to_idx: targetIdxNum,
+                    bubble_idx: undefined,
+                });
+                break;
+            }
+            case 'result': {
+                const [, , winSide] = rest;
+                idx++;
+                packets.push({
+                    id,
+                    idx,
+                    day,
+                    is_day: true,
+                    agents,
+                    event: '終了',
+                    message: winSide,
+                    from_idx: undefined,
+                    to_idx: undefined,
+                    bubble_idx: undefined,
+                });
+                break;
+            }
+        }
+    }
+
+    if (packets.length === 0 && Object.keys(agentsByDay).length > 0) {
+        const agents = getAgentsForDay(0);
+        packets.push({
+            id,
+            idx: 1,
+            day: 0,
+            is_day: true,
+            agents,
+            event: '開始',
+            message: 'ゲームが開始されました',
+            from_idx: undefined,
+            to_idx: undefined,
+            bubble_idx: undefined,
+        });
+    }
+
+    return packets;
+}
+
+interface JSONLogEntry {
+    agent: string;
+    request: string;
+    request_timestamp?: number;
+    response?: string;
+    response_timestamp?: number;
+    error?: string;
+}
+
+interface JSONLogData {
+    game_id: string;
+    win_side: string;
+    agents: { idx: number; team: string; name: string; role: string }[];
+    entries: JSONLogEntry[];
+}
+
+export function convertJSONLogToPackets(text: string): Packet[] {
+    let data: JSONLogData;
+    try {
+        data = JSON.parse(text);
+    } catch {
+        return [];
+    }
+
+    if (!data.game_id || !data.agents || !data.entries) return [];
+
+    const packets: Packet[] = [];
+    let idx = 0;
+
+    const agentNameToIdx: Record<string, number> = {};
+    const agentIdxToRole: Record<number, string> = {};
+
+    for (const agent of data.agents) {
+        agentNameToIdx[agent.name] = agent.idx;
+        agentIdxToRole[agent.idx] = agent.role;
+    }
+
+    const statusByDay: Record<number, Record<number, boolean>> = {};
+
+    function buildAgents(day: number): Agent[] {
+        return data.agents.map((a) => ({
+            idx: a.idx,
+            team: a.team,
+            name: a.name,
+            profile: undefined,
+            avatar: undefined,
+            role: a.role,
+            is_alive: statusByDay[day]?.[a.idx] ?? true,
+        }));
+    }
+
+    function parseStatusMap(statusMap: Record<string, string>, day: number) {
+        if (!statusByDay[day]) statusByDay[day] = {};
+        for (const [name, status] of Object.entries(statusMap)) {
+            const agentIdx = agentNameToIdx[name];
+            if (agentIdx !== undefined) {
+                statusByDay[day][agentIdx] = status === 'ALIVE';
+            }
+        }
+    }
+
+    idx++;
+    packets.push({
+        id: data.game_id,
+        idx,
+        day: 0,
+        is_day: true,
+        agents: buildAgents(0),
+        event: '開始',
+        message: 'ゲームが開始されました',
+        from_idx: undefined,
+        to_idx: undefined,
+        bubble_idx: undefined,
+    });
+
+    for (const entry of data.entries) {
+        let request: any;
+        try {
+            request = JSON.parse(entry.request);
+        } catch {
+            continue;
+        }
+
+        const requestType = request.request;
+        const info = request.info;
+        const day = info?.day ?? 0;
+        const agentName = entry.agent;
+        const agentIdx = agentNameToIdx[agentName];
+
+        if (info?.status_map) {
+            parseStatusMap(info.status_map, day);
+        }
+
+        switch (requestType) {
+            case 'TALK': {
+                const response = entry.response;
+                if (!response) break;
+                idx++;
+                packets.push({
+                    id: data.game_id,
+                    idx,
+                    day,
+                    is_day: true,
+                    agents: buildAgents(day),
+                    event: 'トーク',
+                    message: response,
+                    from_idx: undefined,
+                    to_idx: undefined,
+                    bubble_idx: agentIdx,
+                });
+                break;
+            }
+            case 'WHISPER': {
+                const response = entry.response;
+                if (!response) break;
+                idx++;
+                packets.push({
+                    id: data.game_id,
+                    idx,
+                    day,
+                    is_day: false,
+                    agents: buildAgents(day),
+                    event: '囁き',
+                    message: response,
+                    from_idx: undefined,
+                    to_idx: undefined,
+                    bubble_idx: agentIdx,
+                });
+                break;
+            }
+            case 'VOTE': {
+                const response = entry.response;
+                if (!response) break;
+                const targetIdx = agentNameToIdx[response];
+                if (targetIdx === undefined) break;
+                idx++;
+                packets.push({
+                    id: data.game_id,
+                    idx,
+                    day,
+                    is_day: true,
+                    agents: buildAgents(day),
+                    event: '投票',
+                    message: undefined,
+                    from_idx: agentIdx,
+                    to_idx: targetIdx,
+                    bubble_idx: undefined,
+                });
+                break;
+            }
+            case 'DIVINE': {
+                const response = entry.response;
+                if (!response) break;
+                const targetIdx = agentNameToIdx[response];
+                if (targetIdx === undefined) break;
+                idx++;
+                packets.push({
+                    id: data.game_id,
+                    idx,
+                    day,
+                    is_day: false,
+                    agents: buildAgents(day),
+                    event: '占い',
+                    message: undefined,
+                    from_idx: agentIdx,
+                    to_idx: targetIdx,
+                    bubble_idx: undefined,
+                });
+                break;
+            }
+            case 'GUARD': {
+                const response = entry.response;
+                if (!response) break;
+                const targetIdx = agentNameToIdx[response];
+                if (targetIdx === undefined) break;
+                idx++;
+                packets.push({
+                    id: data.game_id,
+                    idx,
+                    day,
+                    is_day: false,
+                    agents: buildAgents(day),
+                    event: '護衛',
+                    message: undefined,
+                    from_idx: agentIdx,
+                    to_idx: targetIdx,
+                    bubble_idx: undefined,
+                });
+                break;
+            }
+            case 'ATTACK_VOTE': {
+                const response = entry.response;
+                if (!response) break;
+                const targetIdx = agentNameToIdx[response];
+                if (targetIdx === undefined) break;
+                idx++;
+                packets.push({
+                    id: data.game_id,
+                    idx,
+                    day,
+                    is_day: false,
+                    agents: buildAgents(day),
+                    event: '襲撃投票',
+                    message: undefined,
+                    from_idx: agentIdx,
+                    to_idx: targetIdx,
+                    bubble_idx: undefined,
+                });
+                break;
+            }
+        }
+    }
+
+    if (data.win_side && data.win_side !== 'T_NONE') {
+        const lastDay = packets.length > 0 ? packets[packets.length - 1].day : 0;
+        idx++;
+        packets.push({
+            id: data.game_id,
+            idx,
+            day: lastDay,
+            is_day: true,
+            agents: buildAgents(lastDay),
+            event: '終了',
+            message: data.win_side,
+            from_idx: undefined,
+            to_idx: undefined,
+            bubble_idx: undefined,
+        });
+    }
+
+    return packets;
+}
+
+export function detectLogFormat(text: string): 'jsonl' | 'json' | 'gamelog' | 'unknown' {
+    const trimmed = text.trim();
+
+    if (trimmed.startsWith('{') && !trimmed.includes('\n')) {
+        try {
+            const parsed = JSON.parse(trimmed);
+            if (parsed.game_id && parsed.entries) return 'json';
+            if (parsed.id && parsed.idx !== undefined) return 'jsonl';
+        } catch { /* not single-line JSON */ }
+    }
+
+    if (trimmed.startsWith('{')) {
+        try {
+            const parsed = JSON.parse(trimmed);
+            if (parsed.game_id && parsed.entries) return 'json';
+        } catch { /* not JSON object */ }
+    }
+
+    const lines = trimmed.split('\n');
+    if (lines.length > 0) {
+        const firstLine = lines[0].trim();
+
+        if (firstLine.startsWith('{')) {
+            try {
+                const parsed = JSON.parse(firstLine);
+                if (parsed.id !== undefined && parsed.idx !== undefined) return 'jsonl';
+                if (parsed.game_id && parsed.entries) return 'json';
+            } catch { /* not JSONL */ }
+        }
+
+        if (/^\d+,(status|talk|whisper|vote|execute|divine|guard|attackVote|attack|result),/.test(firstLine)) {
+            return 'gamelog';
+        }
+    }
+
+    return 'unknown';
+}

--- a/src/lib/utils/log-converter.ts
+++ b/src/lib/utils/log-converter.ts
@@ -112,12 +112,13 @@ export function convertGameLogToPackets(text: string, gameId?: string): Packet[]
                     }
                 }
                 const text = textParts.join(',');
+                isDay = false;
                 idx++;
                 packets.push({
                     id,
                     idx,
                     day,
-                    is_day: isDay,
+                    is_day: false,
                     agents,
                     event: '囁き',
                     message: text,

--- a/src/lib/utils/log-converter.ts
+++ b/src/lib/utils/log-converter.ts
@@ -387,6 +387,8 @@ export function convertJSONLogToPackets(text: string): Packet[] {
     // Track which talk_history entries we've already emitted (by day+idx)
     const emittedTalks = new Set<string>();
     const emittedWhispers = new Set<string>();
+    const emittedExecutions = new Set<number>();
+    const emittedAttacks = new Set<number>();
 
     for (const entry of data.entries) {
         let request: any;
@@ -397,6 +399,45 @@ export function convertJSONLogToPackets(text: string): Packet[] {
         const day = info?.day ?? 0;
         const agentName = entry.agent;
         const agentIdx = resolveIdx(agentName);
+
+        // Extract execution and attack results from DAILY_INITIALIZE
+        if (requestType === 'DAILY_INITIALIZE' && day > 0) {
+            const prevDay = day - 1;
+            if (info.executed_agent && !emittedExecutions.has(prevDay)) {
+                emittedExecutions.add(prevDay);
+                const executedIdx = resolveIdx(info.executed_agent);
+                packetIdx++;
+                packets.push({
+                    id: data.game_id,
+                    idx: packetIdx,
+                    day: prevDay,
+                    is_day: true,
+                    agents: buildAgents(prevDay),
+                    event: '追放',
+                    message: undefined,
+                    from_idx: undefined,
+                    to_idx: executedIdx,
+                    bubble_idx: undefined,
+                });
+            }
+            if (info.attacked_agent && !emittedAttacks.has(prevDay)) {
+                emittedAttacks.add(prevDay);
+                const attackedIdx = resolveIdx(info.attacked_agent);
+                packetIdx++;
+                packets.push({
+                    id: data.game_id,
+                    idx: packetIdx,
+                    day: prevDay,
+                    is_day: false,
+                    agents: buildAgents(prevDay),
+                    event: '襲撃',
+                    message: undefined,
+                    from_idx: undefined,
+                    to_idx: attackedIdx,
+                    bubble_idx: undefined,
+                });
+            }
+        }
 
         switch (requestType) {
             case 'TALK': {

--- a/src/lib/utils/realtime-socket.ts
+++ b/src/lib/utils/realtime-socket.ts
@@ -1,7 +1,7 @@
 import { realtimeSettings } from '$lib/stores/realtime-settings';
 import type { Packet } from '$lib/types/realtime';
 import type { RealtimeSettings } from '$lib/types/realtime-settings';
-import { convertGameLogToPackets, convertJSONLogToPackets, detectLogFormat } from '$lib/utils/log-converter';
+import { convertGameLogToPackets, convertJSONLogToPackets, detectLogFormat, normalizeTimestamp } from '$lib/utils/log-converter';
 import { writable } from 'svelte/store';
 
 export const RealtimeConnectionStatus = {
@@ -338,6 +338,7 @@ function createRealtimeSocketState() {
             if (line) {
                 try {
                     const packet = JSON.parse(line) as Packet;
+                    packet.timestamp = normalizeTimestamp(packet.timestamp);
                     packets.push(packet);
                 } catch (e) {
                     console.error(`Line ${i + 1} is not valid JSON:`, line);

--- a/src/lib/utils/realtime-socket.ts
+++ b/src/lib/utils/realtime-socket.ts
@@ -1,6 +1,7 @@
 import { realtimeSettings } from '$lib/stores/realtime-settings';
 import type { Packet } from '$lib/types/realtime';
 import type { RealtimeSettings } from '$lib/types/realtime-settings';
+import { convertGameLogToPackets, convertJSONLogToPackets, detectLogFormat } from '$lib/utils/log-converter';
 import { writable } from 'svelte/store';
 
 export const RealtimeConnectionStatus = {
@@ -260,12 +261,29 @@ function createRealtimeSocketState() {
         }
     }
 
-    async function loadFromText(text: string) {
+    async function loadFromText(text: string, filename?: string) {
         if (!text.trim()) {
             return;
         }
 
-        const packets = parseJSONLText(text);
+        const format = detectLogFormat(text);
+        let packets: Packet[];
+
+        switch (format) {
+            case 'jsonl':
+                packets = parseJSONLText(text);
+                break;
+            case 'json':
+                packets = convertJSONLogToPackets(text);
+                break;
+            case 'gamelog':
+                packets = convertGameLogToPackets(text, filename);
+                break;
+            default:
+                packets = parseJSONLText(text);
+                break;
+        }
+
         if (packets.length === 0) {
             console.error('No valid packets found');
             return;
@@ -297,7 +315,7 @@ function createRealtimeSocketState() {
             };
         });
 
-        console.log(`JSONL data loaded: ${packets.length} packets across ${Object.keys(newEntries).length} games`);
+        console.log(`Data loaded (${format}): ${packets.length} packets across ${Object.keys(newEntries).length} games`);
     }
 
     async function loadFromFiles(files: FileList) {
@@ -305,7 +323,7 @@ function createRealtimeSocketState() {
             const reader = new FileReader();
             reader.onload = async (e) => {
                 const text = e.target?.result as string;
-                await loadFromText(text);
+                await loadFromText(text, file.name);
             };
             reader.readAsText(file);
         }

--- a/src/routes/realtime/+page.svelte
+++ b/src/routes/realtime/+page.svelte
@@ -278,6 +278,14 @@
                   </p>
                 {/if}
               </button>
+              {#if (packet.event === "トーク" || packet.event === "囁き") && packet.timestamp != null}
+                {@const entries = $realtimeSocketState.entries[$realtimeSocketState.currentGameId]}
+                {#if idx + 1 < entries.length && (entries[idx + 1].event === "トーク" || entries[idx + 1].event === "囁き") && entries[idx + 1].timestamp != null}
+                  {@const diffMs = entries[idx + 1].timestamp! - packet.timestamp}
+                  {@const diffSec = (diffMs / 1000).toFixed(1)}
+                  <div class="text-xs text-center opacity-50">+{diffSec}s</div>
+                {/if}
+              {/if}
             {/each}
           {/if}
         </div>


### PR DESCRIPTION
## Summary
- リアルタイムビューでサーバーが出力する `.log`（game log CSV形式）と `.json`（JSON logger形式）のファイル読み込みに対応
- ファイル形式を自動検出し、既存のJSONL形式と同様にPacket形式に変換して表示
- Node.js 26.x / pnpm 10.32.1 に package.json を更新

## 変更内容
- `src/lib/utils/log-converter.ts`: game log / JSON log → Packet[] 変換ユーティリティを追加
- `src/lib/utils/realtime-socket.ts`: ファイル読み込み時にフォーマット自動検出を追加
- `package.json`: engines.node を 26.x に、packageManager を pnpm@10.32.1 に更新

## Test plan
- [ ] `.jsonl` ファイルのドラッグ&ドロップが従来通り動作すること
- [ ] `.log` ファイル（game log形式）をドロップして正しくリアルタイムビューに表示されること
- [ ] `.json` ファイル（JSON logger形式）をドロップして正しくリアルタイムビューに表示されること
- [ ] クリップボードからの貼り付けで3形式とも動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)